### PR TITLE
added setup.py to install think*.  import via 'import thinkbayes'

### DIFF
--- a/code/setup.py
+++ b/code/setup.py
@@ -1,0 +1,10 @@
+from distutils.core import setup
+
+setup(name='ThinkBayes',
+      version='1.0',
+      description='ThinkBayes book code',
+      author='Allen Downey',
+      author_email='allen.downey@olin.edu',
+      url='https://github.com/AllenDowney',
+      py_modules=['thinkbayes', 'thinkstats', 'thinkplot'],
+     )


### PR DESCRIPTION
Hi Allen:

I really like using your think*.py code for quick prototyping and testing, esp. via ipython notebook, so I created a simple setup.py to install it. Hardly rocket science, but it makes it possible to use the code from any directory via "import thinkbayes"

Thanks for your great books!  I've made them required reading for all my team.

-- jdm
John David Miller
Principal Research Data Scientist
Intel Corporation